### PR TITLE
change std::assert::require to std::revert::require

### DIFF
--- a/solution_voting/Forc.lock
+++ b/solution_voting/Forc.lock
@@ -1,11 +1,11 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-56CBD671DED0A584'
+source = 'path+from-root-603BAB4590C454D3'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.18.1#3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.19.0#5c716e1ba55d755555ed5aa186c883f73c4f90dc'
 dependencies = ['core']
 
 [[package]]

--- a/solution_voting/src/main.sw
+++ b/solution_voting/src/main.sw
@@ -8,7 +8,7 @@ use errors::*;
 
 use std::{
     contract_id::ContractId,
-    assert::require,
+    revert::require,
     storage::StorageMap,
     identity::Identity,
     context::{call_frames::msg_asset_id, msg_amount, this_balance},


### PR DESCRIPTION
according to this commit https://github.com/FuelLabs/sway/commit/aa5dc0d8127873a4ff6b68a59e184fbbcfd7f809
std::assert::require has been moved to to std::revert::require